### PR TITLE
fix(rockspec): LuaSystem compiles on MinGW

### DIFF
--- a/luasystem-scm-0.rockspec
+++ b/luasystem-scm-0.rockspec
@@ -43,6 +43,10 @@ local function make_platform(plat)
     mingw32 = { },
   }
   local libdirs = {
+    linux = nil,
+    unix = nil,
+    macosx = nil,
+    win32 = nil,
     mingw32 = { },
   }
   return {

--- a/luasystem-scm-0.rockspec
+++ b/luasystem-scm-0.rockspec
@@ -42,6 +42,9 @@ local function make_platform(plat)
     win32 = { "advapi32", "winmm" },
     mingw32 = { },
   }
+  local libdirs = {
+    mingw32 = {}
+  }
   return {
     modules = {
       ['system.core'] = {
@@ -55,6 +58,7 @@ local function make_platform(plat)
         },
         defines = defines[plat],
         libraries = libraries[plat],
+        libdirs = libdirs[plat],
       },
     },
   }

--- a/luasystem-scm-0.rockspec
+++ b/luasystem-scm-0.rockspec
@@ -43,7 +43,7 @@ local function make_platform(plat)
     mingw32 = { },
   }
   local libdirs = {
-    mingw32 = {}
+    mingw32 = { },
   }
   return {
     modules = {


### PR DESCRIPTION
Pre-emptive PR that fixes https://github.com/lunarmodules/luasystem/issues/15 by modifying the rockspec's `build` property to have an empty `libdirs` table when building with MinGW.

I tried applying the same fix as https://github.com/lunarmodules/luasocket/issues/321#issuecomment-1195133551 and it seems to allow the module to compile with `luarocks make` on MinGW.