### PR TITLE
fix: undefined functions when compiling on MinGW

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -19,6 +19,9 @@
 #ifdef _WIN32
 # include <windows.h>
 # include <locale.h>
+# ifdef __MINGW32__
+#  include <conio.h>
+# endif
 #else
 # include <termios.h>
 # include <string.h>


### PR DESCRIPTION
Fixes #25 by including `conio.h`, when a mingw platform.