### PR TITLE
chore(term): add descriptive error on Windows for lack of VT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The scope of what is covered by the version number excludes:
 
 ## Version history
 
+### unreleased
+
+- Chore: add compiler error on Windows if Virtual Terminal Processing is unavailable.
+
 ### Version 0.4.2, released 25-Jun-2024
 
 - Fix: include additional headers for some MinGW installations

--- a/src/term.c
+++ b/src/term.c
@@ -107,6 +107,11 @@ typedef struct ls_RegConst {
 // This is needed because some flags are not defined on all platforms. So we
 // still export the constants, but they will be all 0, and hence not do anything.
 #ifdef _WIN32
+// check compatibility: Windows virtual terminal processing was added in 2015,
+// some older compiler suites don't have the proper headers.
+#ifndef ENABLE_VIRTUAL_TERMINAL_INPUT
+#error Virtual terminal macros are undefined (eg. ENABLE_VIRTUAL_TERMINAL_INPUT). Update the toolchain or revert to Luasystem < 0.4
+#endif
 #define CHECK_WIN_FLAG_OR_ZERO(flag) flag
 #define CHECK_NIX_FLAG_OR_ZERO(flag) 0
 #else


### PR DESCRIPTION
if no virtual terminal processing is available, raise a descriptive error instead of a failure on some missing defines.

closes #29 