### PR TITLE
Re-add FreeBSD support (broken since c1a64c1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The scope of what is covered by the version number excludes:
 ### unreleased
 
 - Chore: add compiler error on Windows if Virtual Terminal Processing is unavailable.
+- Fix: fix the freebsd build
 
 ### Version 0.4.2, released 25-Jun-2024
 

--- a/doc_topics/02-development.md
+++ b/doc_topics/02-development.md
@@ -8,5 +8,5 @@ The tests concerned are all labelled with `#manual`. And in CI they will
 be skipped because `--exclude-tags=manual` is being passed to the
 `busted` command line.
 
-Hence if tests like this are being added, then please ensure the tests
+Hence if tests like these are being added, then please ensure the tests
 pass locally, and do not rely on CI only.

--- a/spec/04-term_spec.lua
+++ b/spec/04-term_spec.lua
@@ -27,7 +27,8 @@ describe("Terminal:", function()
       assert(type(serr) == "boolean", "serr must be a boolean")
 
       local tmpfile = "./spec/04-term_helper.output"
-      local execcmd = "lua ./spec/04-term_helper.lua -- " .. tmpfile
+      local lua_bin = system.getenv("LUA") or "lua"
+      local execcmd = lua_bin .. " ./spec/04-term_helper.lua -- " .. tmpfile
 
       sin = sin and "" or 'echo "hello" | '
       if system.windows then

--- a/src/term.c
+++ b/src/term.c
@@ -166,7 +166,7 @@ static const struct ls_RegConst nix_console_i_flags[] = {
     {"I_INLCR", CHECK_NIX_FLAG_OR_ZERO(INLCR)},
     {"I_IGNCR", CHECK_NIX_FLAG_OR_ZERO(IGNCR)},
     {"I_ICRNL", CHECK_NIX_FLAG_OR_ZERO(ICRNL)},
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
     {"I_IUCLC", CHECK_NIX_FLAG_OR_ZERO(IUCLC)}, // Might not be available on all systems
 #else
     {"I_IUCLC", 0},
@@ -181,7 +181,7 @@ static const struct ls_RegConst nix_console_i_flags[] = {
 static const struct ls_RegConst nix_console_o_flags[] = {
     // Output flags (c_oflag)
     {"O_OPOST", CHECK_NIX_FLAG_OR_ZERO(OPOST)},
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
     {"O_OLCUC", CHECK_NIX_FLAG_OR_ZERO(OLCUC)}, // Might not be available on all systems
 #else
     {"O_OLCUC", 0},
@@ -190,14 +190,27 @@ static const struct ls_RegConst nix_console_o_flags[] = {
     {"O_OCRNL", CHECK_NIX_FLAG_OR_ZERO(OCRNL)},
     {"O_ONOCR", CHECK_NIX_FLAG_OR_ZERO(ONOCR)},
     {"O_ONLRET", CHECK_NIX_FLAG_OR_ZERO(ONLRET)},
+#ifndef __FreeBSD__
     {"O_OFILL", CHECK_NIX_FLAG_OR_ZERO(OFILL)},
     {"O_OFDEL", CHECK_NIX_FLAG_OR_ZERO(OFDEL)},
     {"O_NLDLY", CHECK_NIX_FLAG_OR_ZERO(NLDLY)},
     {"O_CRDLY", CHECK_NIX_FLAG_OR_ZERO(CRDLY)},
+#else
+    {"O_OFILL", 0},
+    {"O_OFDEL", 0},
+    {"O_NLDLY", 0},
+    {"O_CRDLY", 0},
+#endif
     {"O_TABDLY", CHECK_NIX_FLAG_OR_ZERO(TABDLY)},
+#ifndef __FreeBSD__
     {"O_BSDLY", CHECK_NIX_FLAG_OR_ZERO(BSDLY)},
     {"O_VTDLY", CHECK_NIX_FLAG_OR_ZERO(VTDLY)},
     {"O_FFDLY", CHECK_NIX_FLAG_OR_ZERO(FFDLY)},
+#else
+    {"O_BSDLY", 0},
+    {"O_VTDLY", 0},
+    {"O_FFDLY", 0},
+#endif
     {NULL, 0}
 };
 
@@ -205,7 +218,7 @@ static const struct ls_RegConst nix_console_l_flags[] = {
     // Local flags (c_lflag)
     {"L_ISIG", CHECK_NIX_FLAG_OR_ZERO(ISIG)},
     {"L_ICANON", CHECK_NIX_FLAG_OR_ZERO(ICANON)},
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
     {"L_XCASE", CHECK_NIX_FLAG_OR_ZERO(XCASE)}, // Might not be available on all systems
 #else
     {"L_XCASE", 0},


### PR DESCRIPTION
here's the code by the original author: https://git.netizen.se/luasystem/log/?h=fix/freebsd-v0.4.2