### PR TITLE
chore(random): replace deprecated Windows API, improve linux+Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The scope of what is covered by the version number excludes:
 ### unreleased
 
 - Fix: NetBSD fix compilation, undeclared directives
+- Refactor: random bytes; remove deprecated API usage on Windows, move to
+  binary api instead of /dev/urandom file on linux and bsd
 
 ### version 0.4.5, released 18-Dec-2024
 

--- a/luasystem-scm-0.rockspec
+++ b/luasystem-scm-0.rockspec
@@ -39,7 +39,7 @@ local function make_platform(plat)
     linux = { "rt" },
     unix = { },
     macosx = { },
-    win32 = { "advapi32", "winmm" },
+    win32 = { "advapi32", "winmm", "bcrypt" },
     mingw32 = { },
   }
   local libdirs = {


### PR DESCRIPTION
The Windows API used is deprecated, and hence now replaced with the current one.

For Mac and Linux, switch to an api instead of file based on /dev/urandom. The latter remains as a fallback.