### PR TITLE
feat(readkey): allow a sleep function to be passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The scope of what is covered by the version number excludes:
 
 - Feat: when detecting character display width, also accept unicode codepoints (integers),
   since the Lua utf8 library returns codepoints, not strings
+- Feat: allow passing in a sleep function to `readkey` and `readansi`
 - Fix: NetBSD fix compilation, undeclared directives
 - Refactor: random bytes; remove deprecated API usage on Windows, move to
   binary api instead of /dev/urandom file on linux and bsd

--- a/doc_topics/03-terminal.md
+++ b/doc_topics/03-terminal.md
@@ -112,10 +112,10 @@ To use non-blocking input here's how to set it up:
     sys.setnonblock(io.stdin, true)
 
 
-Both functions require a timeout to be provided which allows for proper asynchronous
-code to be written. Since the underlying sleep method used is `system.sleep`, just patching
-that function with a coroutine based yielding one should be all that is needed to make
-the result work with asynchroneous coroutine schedulers.
+Both `readkey` and `readansi` require a timeout to be provided which allows for proper asynchronous
+code to be written. The underlying sleep method to use can be provided, and defaults to `system.sleep`.
+Just passing a coroutine enabled sleep method should be all that is needed to make
+the result work with asynchroneous coroutine schedulers. Alternatively just patch `system.sleep`.
 
 ### 3.3.2 Blocking input
 

--- a/examples/readline.lua
+++ b/examples/readline.lua
@@ -144,10 +144,12 @@ readline.__index = readline
 -- @tparam[opt=""] string opts.value the default value
 -- @tparam[opt=`#value`] number opts.position of the cursor in the input
 -- @tparam[opt={"\10"/"\13"}] table opts.exit_keys an array of keys that will cause the readline to exit
+-- @tparam[opt=system.sleep] function opts.fsleep the sleep function to use (see `system.readansi`)
 -- @treturn readline the new readline object
 function readline.new(opts)
   local value = utf8parse(opts.value or "")
   local prompt = utf8parse(opts.prompt or "")
+  local fsleep = opts.fsleep or sys.sleep
   local pos = math.floor(opts.position or (#value + 1))
   pos = math.max(math.min(pos, (#value + 1)), 1)
   local len = math.floor(opts.max_length or 80)
@@ -175,6 +177,7 @@ function readline.new(opts)
     position = pos,         -- the current position in the input
     drawn_before = false,   -- if the prompt has been drawn
     exit_keys = exit_keys,  -- the keys that will cause the readline to exit
+    fsleep = fsleep,        -- the sleep function to use
   }
 
   setmetatable(self, readline)
@@ -413,7 +416,7 @@ function readline:__call(timeout, redraw)
   local timeout_end = sys.gettime() + timeout
 
   while true do
-    local key, keytype = sys.readansi(timeout_end - sys.gettime())
+    local key, keytype = sys.readansi(timeout_end - sys.gettime(), self.fsleep)
     if not key then
       -- error or timeout
       return nil, keytype
@@ -458,6 +461,7 @@ local rl = readline.new{
   value = "Hello, 你-好 World 🚀!",
   -- position = 2,
   exit_keys = {key_sequences.enter, "\27", "\t", "\27[Z"}, -- enter, escape, tab, shift-tab
+  fsleep = sys.sleep,
 }
 
 


### PR DESCRIPTION
There are cases where both a blocking and non-blocking sleep is needed. In those cases just patching system.sleep isn't good enough. Hence now we can pass a sleep function.