### PR TITLE
change(input): maximum sleep delay on backoff 0.1 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,13 @@ The scope of what is covered by the version number excludes:
 
 ## Version history
 
+### version x.x.x, unreleased
+
+- Fix: maximum key-delay, reduced from 0.2 to 0.1 seconds to reduce slugginess feel on some key presses.
+
 ### version 0.6.2, released 15-Apr-2025
 
- - Fix: autotermrestore didn't work because its metatable was overwritten.
+- Fix: autotermrestore didn't work because its metatable was overwritten.
 
 ### version 0.6.1, released 13-Apr-2025
 

--- a/system/init.lua
+++ b/system/init.lua
@@ -239,7 +239,7 @@ end
 do
   --- Reads a single byte from the console, with a timeout.
   -- This function uses `fsleep` to wait until either a byte is available or the timeout is reached.
-  -- The sleep period is exponentially backing off, starting at 0.0125 seconds, with a maximum of 0.2 seconds.
+  -- The sleep period is exponentially backing off, starting at 0.0125 seconds, with a maximum of 0.1 seconds.
   -- It returns immediately if a byte is available or if `timeout` is less than or equal to `0`.
   --
   -- Using `system.readansi` is preferred over this function. Since this function can leave stray/invalid
@@ -263,7 +263,7 @@ do
         return nil, err
       end
       timeout = timeout - interval
-      interval = math.min(0.2, interval * 2)
+      interval = math.min(0.1, interval * 2)
       key = system._readkey()
     end
 


### PR DESCRIPTION
Curent setting of 0.2 sometimes makes the response feel sluggish.