### PR TITLE
fix(compat): duplicate symbol when linking with luajit on windows

### DIFF
--- a/src/compat.c
+++ b/src/compat.c
@@ -1,7 +1,7 @@
 #include <lua.h>
 #include <lauxlib.h>
 
-#if LUA_VERSION_NUM == 501
+#if LUA_VERSION_NUM == 501 && !defined(LUAJIT_VERSION)
 void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup) {
     luaL_checkstack(L, nup+1, "too many upvalues");
     for (; l->name != NULL; l++) {  /* fill the table with given functions */

--- a/src/compat.h
+++ b/src/compat.h
@@ -4,7 +4,7 @@
 #include <lua.h>
 #include <lauxlib.h>
 
-#if LUA_VERSION_NUM == 501
+#if LUA_VERSION_NUM == 501 && !defined(LUAJIT_VERSION)
 void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup);
 void *luaL_testudata(lua_State *L, int ud, const char *tname);
 #endif


### PR DESCRIPTION
`luaL_testudata` and `luaL_setfuncs` [are defined in LuaJIT's `lauxlib.h`](https://github.com/LuaJIT/LuaJIT/blob/707c12bf00dafdfd3899b1a6c36435dbbf6c7022/src/lauxlib.h#L88).
When linking luasystem with LuaJIT on Windows, I get:

```
luajit.lib(lj_api.obj) : error LNK2005: luaL_testudata already defined in 7aad4293ba004fa7-compat.o\r\nluajit.lib(lib_aux.obj) : error LNK2005: luaL_setfuncs already defined in 7aad4293ba004fa7-compat.o
...
fatal error LNK1169: one or more multiply defined symbols found
```

This PR adds a check to disable the compat symbols if `LUAJIT_VERSION` is defined.